### PR TITLE
Remove an extra `.` in an ellipsis

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -28,7 +28,7 @@ MODULE = PHP::Serialization::XS		PACKAGE = PHP::Serialization::XS
 PROTOTYPES: ENABLE
 
 SV *
-_c_decode(SV *input, SV *preference, ....)
+_c_decode(SV *input, SV *preference, ...)
     CODE:
         struct ps_parser_state *ps_state;
         ps_parser_error_handler = _register_error;


### PR DESCRIPTION
See <https://rt.cpan.org/Ticket/Display.html?id=167875> from <SREZIC@cpan.org>.